### PR TITLE
test theme

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -230,6 +230,33 @@ const midnight = {
   logoColor: '#ecf0f1'
 }
 
+const cyberpunk = {
+  backgroundColor: '#0D0221',
+  textColor: '#FF71CE',
+  textColorSecondary: 'rgba(255, 113, 206, 0.7)',
+  badgeColors: {
+    [Rating.S]: '#B967FF', // Neon purple
+    [Rating.A]: '#01FFC3', // Neon cyan
+    [Rating.B]: '#FFE502', // Neon yellow
+    [Rating.C]: '#01FFFF', // Bright cyan
+    [Rating.D]: '#FF6B6B', // Neon red
+    [Rating.E]: '#FF2975'  // Hot pink
+  },
+  badgeTextColors: {
+    [Rating.S]: '#0D0221',
+    [Rating.A]: '#0D0221',
+    [Rating.B]: '#0D0221',
+    [Rating.C]: '#0D0221',
+    [Rating.D]: '#0D0221',
+    [Rating.E]: '#0D0221'
+  },
+  barBackground: '#1A1147',
+  barForeground: '#01FFC3',
+  borderColor: '#B967FF',
+  avatarPlaceholderColor: '#7D12FF',
+  logoColor: '#FF71CE',
+}
+
 export const preset: Record<string, Theme> = {
   light,
   dark,
@@ -239,4 +266,5 @@ export const preset: Record<string, Theme> = {
   tokyoNight,
   nord,
   midnight,
+  cyberpunk,
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -231,30 +231,30 @@ const midnight = {
 }
 
 const cyberpunk = {
-  backgroundColor: '#0D0221',
-  textColor: '#FF71CE',
-  textColorSecondary: 'rgba(255, 113, 206, 0.7)',
+  backgroundColor: '#FFFAE3',
+  textColor: '#7209B7',
+  textColorSecondary: 'rgba(114, 9, 183, 0.7)',
   badgeColors: {
-    [Rating.S]: '#B967FF', // Neon purple
-    [Rating.A]: '#01FFC3', // Neon cyan
-    [Rating.B]: '#FFE502', // Neon yellow
-    [Rating.C]: '#01FFFF', // Bright cyan
-    [Rating.D]: '#FF6B6B', // Neon red
-    [Rating.E]: '#FF2975'  // Hot pink
+    [Rating.S]: '#B967FF',
+    [Rating.A]: '#00B4D8',
+    [Rating.B]: '#F72585',
+    [Rating.C]: '#4CC9F0',
+    [Rating.D]: '#7209B7',
+    [Rating.E]: '#3A0CA3'
   },
   badgeTextColors: {
-    [Rating.S]: '#0D0221',
-    [Rating.A]: '#0D0221',
-    [Rating.B]: '#0D0221',
-    [Rating.C]: '#0D0221',
-    [Rating.D]: '#0D0221',
-    [Rating.E]: '#0D0221'
+    [Rating.S]: '#FFFAE3',
+    [Rating.A]: '#FFFAE3',
+    [Rating.B]: '#FFFAE3',
+    [Rating.C]: '#FFFAE3',
+    [Rating.D]: '#FFFAE3',
+    [Rating.E]: '#FFFAE3'
   },
-  barBackground: '#1A1147',
-  barForeground: '#01FFC3',
+  barBackground: '#FFE5D9',
+  barForeground: '#7209B7',
   borderColor: '#B967FF',
   avatarPlaceholderColor: '#7D12FF',
-  logoColor: '#FF71CE',
+  logoColor: '#7209B7',
 }
 
 export const preset: Record<string, Theme> = {


### PR DESCRIPTION
This pull request introduces a new theme called `cyberpunk` to the `src/theme.ts` file. The changes add the new theme's color scheme and include it in the `preset` export.

New theme addition:

* [`src/theme.ts`](diffhunk://#diff-0e21fb1c9519a397050defc2148a2d1b966a0982cc4cf196e1e6b007f8d095e5R233-R259): Added a new theme named `cyberpunk` with specific background, text, badge, bar, border, avatar placeholder, and logo colors.

Inclusion in presets:

* [`src/theme.ts`](diffhunk://#diff-0e21fb1c9519a397050defc2148a2d1b966a0982cc4cf196e1e6b007f8d095e5R269): Included the `cyberpunk` theme in the `preset` export to make it available for use.