### PR TITLE
ci: use another workflow to commit preview images

### DIFF
--- a/.github/workflows/commit-preview.yml
+++ b/.github/workflows/commit-preview.yml
@@ -1,0 +1,99 @@
+name: Commit Preview
+
+on:
+    workflow_run:
+        workflows: ["PR Preview"]
+        types:
+            - completed
+
+jobs:
+    commit:
+        runs-on: ubuntu-latest
+        if: github.event.workflow_run.conclusion == 'success'
+        permissions:
+            contents: write
+
+        steps:
+            - name: Download preview artifact
+              uses: dawidd6/action-download-artifact@v7
+              with:
+                  run_id: ${{ github.event.workflow_run.id }}
+                  name: preview-image
+                  path: .
+
+            - name: Download PR info artifact
+              uses: dawidd6/action-download-artifact@v7
+              with:
+                  run_id: ${{ github.event.workflow_run.id }}
+                  name: pr-info
+                  path: .
+
+            - name: Read PR info
+              id: pr-info
+              run: |
+                  echo "pr_number=$(cat pr_number.txt)" >> $GITHUB_OUTPUT
+                  echo "commit_sha=$(cat commit_sha.txt)" >> $GITHUB_OUTPUT
+                  echo "new_themes=$(cat new_themes.txt)" >> $GITHUB_OUTPUT
+                  echo "theme=$(cat theme.txt)" >> $GITHUB_OUTPUT
+
+            - name: Setup preview branch
+              run: |
+                  # Configure git
+                  git config --global user.name 'github-actions[bot]'
+                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+                  # Clone only the preview branch, or create new if doesn't exist
+                  if git ls-remote --heads origin previews | grep -q 'refs/heads/previews'; then
+                      git clone --branch previews --single-branch https://github.com/${{ github.repository }}.git .
+                  else
+                      git clone https://github.com/${{ github.repository }}.git .
+                      git checkout --orphan previews
+                      git rm -rf .
+                      git clean -fxd
+                  fi
+
+                  # Setup the preview branch
+                  mkdir -p previews
+
+                  # Copy the new preview with PR number and commit SHA
+                  cp preview.png "previews/pr-${{ steps.pr-info.outputs.pr_number }}-${{ steps.pr-info.outputs.commit_sha }}.png"
+
+                  # Commit and push
+                  git add previews/
+                  git commit -m "Update preview for PR #${{ steps.pr-info.outputs.pr_number }} commit ${{ steps.pr-info.outputs.commit_sha }}" || echo "No changes to commit"
+                  git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git previews
+
+            - name: Find Comment
+              uses: peter-evans/find-comment@v3
+              id: find-comment
+              with:
+                  issue-number: ${{ steps.pr-info.outputs.pr_number }}
+                  comment-author: "github-actions[bot]"
+                  body-includes: "### GitRoll Preview Cards"
+
+            - name: Create comment body
+              id: create-comment
+              run: |
+                  IMAGE_URL="https://raw.githubusercontent.com/${{ github.repository }}/previews/previews/pr-${{ steps.pr-info.outputs.pr_number }}-${{ steps.pr-info.outputs.commit_sha }}.png"
+
+                  echo "body<<EOF" >> $GITHUB_OUTPUT
+                  echo "### GitRoll Preview Cards" >> $GITHUB_OUTPUT
+                  echo "" >> $GITHUB_OUTPUT
+                  if [[ -n "${{ steps.pr-info.outputs.new_themes }}" ]]; then
+                      echo "New theme(s) detected: \`${{ steps.pr-info.outputs.new_themes }}\`" >> $GITHUB_OUTPUT
+                  else
+                      echo "No new theme detected, using: \`${{ steps.pr-info.outputs.theme }}\`" >> $GITHUB_OUTPUT
+                  fi
+                  echo "" >> $GITHUB_OUTPUT
+                  echo "![Preview Cards]($IMAGE_URL)" >> $GITHUB_OUTPUT
+                  echo "" >> $GITHUB_OUTPUT
+                  echo "These are preview cards showing possible ratings. Get your real score at [GitRoll.io](https://gitroll.io)" >> $GITHUB_OUTPUT
+                  echo "EOF" >> $GITHUB_OUTPUT
+
+            - name: Create or update comment
+              uses: peter-evans/create-or-update-comment@v4
+              with:
+                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
+                  issue-number: ${{ steps.pr-info.outputs.pr_number }}
+                  body: ${{ steps.create-comment.outputs.body }}
+                  edit-mode: replace

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -9,7 +9,6 @@ jobs:
         runs-on: ubuntu-latest
         permissions:
             pull-requests: write
-            contents: write
 
         steps:
             - name: Checkout PR Branch
@@ -66,70 +65,27 @@ jobs:
                       exit 1
                   }
 
-            - name: Setup preview branch
-              run: |
-                  # Create a temporary directory for the preview branch
-                  TEMP_DIR=$(mktemp -d)
-
-                  # Configure git
-                  git config --global user.name 'github-actions[bot]'
-                  git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-
-                  # Clone only the preview branch to temp dir, or create new if doesn't exist
-                  if git ls-remote --heads origin previews | grep -q 'refs/heads/previews'; then
-                      git clone --branch previews --single-branch https://github.com/${{ github.repository }}.git "$TEMP_DIR"
-                  else
-                      git clone https://github.com/${{ github.repository }}.git "$TEMP_DIR"
-                      cd "$TEMP_DIR"
-                      git checkout --orphan previews
-                      git rm -rf .
-                      git clean -fxd
-                  fi
-
-                  # Setup the preview branch
-                  cd "$TEMP_DIR"
-                  mkdir -p previews
-
-                  # Copy the new preview with PR number and commit SHA
-                  cp "${{ github.workspace }}/preview.png" "previews/pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}.png"
-
-                  # Commit and push
-                  git add previews/
-                  git commit -m "Update preview for PR #${{ github.event.pull_request.number }} commit ${{ github.event.pull_request.head.sha }}" || echo "No changes to commit"
-                  git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git previews
-
-            - name: Get comment body
-              id: get-comment-body
-              run: |
-                  # Use raw GitHub URL for the image with commit SHA
-                  IMAGE_URL="https://raw.githubusercontent.com/${{ github.repository }}/previews/previews/pr-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}.png"
-
-                  echo "body<<EOF" >> $GITHUB_OUTPUT
-                  echo "### GitRoll Preview Cards" >> $GITHUB_OUTPUT
-                  echo "" >> $GITHUB_OUTPUT
-                  if [[ -n "${{ steps.get-theme.outputs.new_themes }}" ]]; then
-                      echo "New theme(s) detected: \`${{ steps.get-theme.outputs.new_themes }}\`" >> $GITHUB_OUTPUT
-                  else
-                      echo "No new theme detected, using: \`${{ steps.get-theme.outputs.theme }}\`" >> $GITHUB_OUTPUT
-                  fi
-                  echo "" >> $GITHUB_OUTPUT
-                  echo "![Preview Cards]($IMAGE_URL)" >> $GITHUB_OUTPUT
-                  echo "" >> $GITHUB_OUTPUT
-                  echo "These are preview cards showing possible ratings. Get your real score at [GitRoll.io](https://gitroll.io)" >> $GITHUB_OUTPUT
-                  echo "EOF" >> $GITHUB_OUTPUT
-
-            - name: Find Comment
-              uses: peter-evans/find-comment@v3
-              id: find-comment
+            - name: Upload preview artifact
+              uses: actions/upload-artifact@v4
               with:
-                  issue-number: ${{ github.event.pull_request.number }}
-                  comment-author: "github-actions[bot]"
-                  body-includes: "### GitRoll Preview Cards"
+                  name: preview-image
+                  path: preview.png
+                  retention-days: 1
 
-            - name: Create or update comment
-              uses: peter-evans/create-or-update-comment@v4
+            - name: Save PR info
+              run: |
+                  echo "${{ github.event.pull_request.number }}" > pr_number.txt
+                  echo "${{ github.event.pull_request.head.sha }}" > commit_sha.txt
+                  echo "${{ steps.get-theme.outputs.new_themes }}" > new_themes.txt
+                  echo "${{ steps.get-theme.outputs.theme }}" > theme.txt
+
+            - name: Upload PR info artifact
+              uses: actions/upload-artifact@v4
               with:
-                  comment-id: ${{ steps.find-comment.outputs.comment-id }}
-                  issue-number: ${{ github.event.pull_request.number }}
-                  body: ${{ steps.get-comment-body.outputs.body }}
-                  edit-mode: replace
+                  name: pr-info
+                  path: |
+                      pr_number.txt
+                      commit_sha.txt
+                      new_themes.txt
+                      theme.txt
+                  retention-days: 1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for commit previews and refactors the existing PR preview workflow to streamline the process. The most important changes include adding a new `commit-preview.yml` file, removing redundant steps from the `pr-preview.yml` file, and updating permissions.

New Commit Preview Workflow:

* Added a new workflow file `.github/workflows/commit-preview.yml` to handle commit previews. This workflow runs on successful completion of the "PR Preview" workflow and includes steps for downloading artifacts, setting up a preview branch, and creating or updating comments with preview images.

Refactoring PR Preview Workflow:

* Removed the setup and push steps for the preview branch from `.github/workflows/pr-preview.yml` and replaced them with steps to upload artifacts (`preview-image` and `pr-info`). This simplifies the workflow by delegating the preview branch setup to the new commit preview workflow.
* Updated permissions in `.github/workflows/pr-preview.yml` to remove unnecessary `contents: write` permission, ensuring more secure access control.